### PR TITLE
Added Linux to getOS function

### DIFF
--- a/lib/js/script.js
+++ b/lib/js/script.js
@@ -4,6 +4,8 @@ function getOS() {
     OS = { name: "Windows", file: ".exe" };
   if (navigator.appVersion.indexOf("Mac") != -1)
     OS = { name: "macOS", file: ".dmg" };
+  if (navigator.appVersion.indexOf("Linux") != -1)
+      OS = { name: "Linux", file: ".AppImage" };
 
   return OS;
 }


### PR DESCRIPTION
Added Linux to getOS function in script.js. This fulfils the feature request described in issue #52.