### PR TITLE
Incorrect latin translation

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
 	<section class="section about">
 		<div class="wrapper">
 			<h2>The story behind Alva</h2>
-			<p>»Alva« is the middle name of Thomas Alva Edison, who made electricity available to the public. And in Latin, »Alva« means Wisdom. We started Alva in August 2017 as an initiative at <a href="https://sinnerschrader.com" target="_blank">SinnerSchrader</a> and since then a quite small, but very powerful product design and engineering team is working hard on building and evolving the Alva app and its ecosystem. </p>
+			<p>»Alva« is the middle name of Thomas Alva Edison, who made electricity available to the public. We started Alva in August 2017 as an initiative at <a href="https://sinnerschrader.com" target="_blank">SinnerSchrader</a> and since then a quite small, but very powerful product design and engineering team is working hard on building and evolving the Alva app and its ecosystem. </p>
 
 			<h3>Our core team</h3>
 			<div class="about-people">


### PR DESCRIPTION
Alva in latin doesn't exist, maybe you wanted alba. If so, alba means white. not wisdom.